### PR TITLE
Feature/delete race result and change from horse race result to horse race

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,6 @@ gem 'nokogiri', '~> 1.10', '>= 1.10.10'
 gem 'httparty', '~> 0.18.1'
 gem 'selenium-webdriver', '~> 3.142', '>= 3.142.7'
 gem 'webdrivers', '~> 4.4', '>= 4.4.1'
+
+# translate english to japanese
+gem 'rails-i18n'

--- a/Gemfile
+++ b/Gemfile
@@ -75,4 +75,4 @@ gem 'selenium-webdriver', '~> 3.142', '>= 3.142.7'
 gem 'webdrivers', '~> 4.4', '>= 4.4.1'
 
 # translate english to japanese
-gem 'rails-i18n'
+gem 'rails-i18n', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -295,6 +298,7 @@ DEPENDENCIES
   pry-rails (~> 0.3.9)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
+  rails-i18n
   rspec-rails (~> 3.6.0)
   rubocop (~> 0.87)
   rubocop-performance (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ DEPENDENCIES
   pry-rails (~> 0.3.9)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
-  rails-i18n
+  rails-i18n (~> 6.0)
   rspec-rails (~> 3.6.0)
   rubocop (~> 0.87)
   rubocop-performance (~> 1.8)

--- a/app/controllers/horses_controller.rb
+++ b/app/controllers/horses_controller.rb
@@ -8,10 +8,7 @@ class HorsesController < ApplicationController
 
   def show
     @horse = Horse.find(params[:id])
-    @horse_race_results = @horse
-                          .horse_race_results
-                          .includes(:race)
-                          .order('races.start DESC')
+    @horse_races = @horse.horse_races.includes(:race).order('races.start DESC')
     @graph_points = GenerateRpciAve1fScatterPlotsService.new(@horse).call
   end
 end

--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -8,6 +8,6 @@ class RacesController < ApplicationController
 
   def show
     @race = Race.find(params[:id])
-    @race_horses = @race.race_horses.order('horse_number')
+    @horse_races = @race.horse_races.order('horse_number')
   end
 end

--- a/app/helpers/races_helper.rb
+++ b/app/helpers/races_helper.rb
@@ -3,7 +3,7 @@ module RacesHelper
     race.attributes
       .merge('start' => race.start.to_s(:date_hour_min),
              'day_number' => race.day_number.try { |number| "#{number}日目" },
-             'course' => I18n.t("enums.race.course.#{race.course}"),
+             'course' => t("enums.race.course.#{race.course}"),
              'round' => "#{race.round}R")
       .values_at('start',
                  'day_number',
@@ -14,13 +14,13 @@ module RacesHelper
 
   def race_condition(race)
     race.attributes
-      .merge('course_type' => I18n.t("enums.race.course_type.#{race.course_type}"),
+      .merge('course_type' => t("enums.race.course_type.#{race.course_type}"),
              'distance' => "#{race.distance}m",
-             'turn' => I18n.t("enums.race.turn.#{race.turn}"),
-             'side' => race.side.try { |side| I18n.t("enums.race.side.#{side}") })
+             'turn' => t("enums.race.turn.#{race.turn}"),
+             'side' => race.side.try { |side| t("enums.race.side.#{side}") })
       .values_at('course_type', 'distance', 'turn', 'side')
       .concat(race.race_regulations.map do |regulation|
-        I18n.t("enums.race_regulation.#{regulation.regulation}")
+        t("enums.race_regulation.#{regulation.regulation}")
       end)
       .reject(&:blank?).join(' ')
   end

--- a/app/models/horse.rb
+++ b/app/models/horse.rb
@@ -2,10 +2,6 @@
 # Horse Model
 #
 class Horse < ApplicationRecord
-  has_many :horse_race_results
-  has_many :race_horses
-  # TODO
-  ## race_horse は廃止。horse_race_result は horse_race に修正して統一する
-  has_many :races, through: :horse_race_results
-  # has_many :races, through: :race_horses
+  has_many :horse_races
+  has_many :races, through: :horse_races
 end

--- a/app/models/horse_race.rb
+++ b/app/models/horse_race.rb
@@ -1,7 +1,7 @@
 #
-# HorseRaceResult Model
+# HorseRace Model
 #
-class HorseRaceResult < ApplicationRecord
+class HorseRace < ApplicationRecord
   self.primary_keys = :horse_id, :race_id
   belongs_to :horse
   belongs_to :race

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -2,11 +2,10 @@
 # Race Model
 #
 class Race < ApplicationRecord
-  has_many :race_horses
-  has_many :horses, through: :race_horses
+  has_many :horse_races
+  has_many :horses, through: :horse_races
   has_many :race_regulations
   has_many :race_prizes
-  has_many :horse_race_results
   has_one :race_result
 
   # TODO 海外, 地方の競馬場が必要になった時にここに追加する

--- a/app/models/race_horse.rb
+++ b/app/models/race_horse.rb
@@ -1,4 +1,0 @@
-class RaceHorse < ApplicationRecord
-  belongs_to :horse
-  belongs_to :race
-end

--- a/app/services/generate_rpci_ave1f_scatter_plots_service.rb
+++ b/app/services/generate_rpci_ave1f_scatter_plots_service.rb
@@ -12,8 +12,8 @@ class GenerateRpciAve1fScatterPlotsService
   end
 
   def call
-    horse.horse_race_results.map do |horse_race_result|
-      generate_scatter_plot(horse_race_result)
+    horse.horse_races.map do |horse_race|
+      generate_scatter_plot(horse_race)
     end
   end
 
@@ -21,22 +21,22 @@ class GenerateRpciAve1fScatterPlotsService
 
   attr_reader :horse
 
-  def generate_scatter_plot(horse_race_result)
-    scatter_plot(horse_race_result, scatter_plot_color(horse_race_result))
+  def generate_scatter_plot(horse_race)
+    scatter_plot(horse_race, scatter_plot_color(horse_race))
   end
 
-  def scatter_plot(horse_race_result, color)
-    { name: horse_race_result.race.name,
-      data: [[horse_race_result.race.race_result.RPCI, horse_race_result.race.race_result.ave_1F]],
+  def scatter_plot(horse_race, color)
+    { name: horse_race.race.name,
+      data: [[horse_race.race.race_result.RPCI, horse_race.race.race_result.ave_1F]],
       color: color }
   end
 
-  def scatter_plot_color(horse_race_result)
-    if horse_race_result.order_of_arrival == 1
+  def scatter_plot_color(horse_race)
+    if horse_race.order_of_arrival == 1
       WON_RACE_COLOR
-    elsif horse_race_result.time_diff.to_f <= 0.2
+    elsif horse_race.time_diff.to_f <= 0.2
       RACE_LOST_BY_0_POINT_2_SECONDS_COLOR
-    elsif horse_race_result.time_diff.to_f <= 1.0
+    elsif horse_race.time_diff.to_f <= 1.0
       RACE_LOST_BY_1_SECOND_COLOR
     else
       RACE_LOST_BY_MORE_THAN_1_SECOND_COLOR

--- a/app/services/scraper/horse_race_scraper_service.rb
+++ b/app/services/scraper/horse_race_scraper_service.rb
@@ -1,9 +1,9 @@
 module Scraper
-  # HorseRaceResultモデルのスクレイピングを実施
-  # Usage: Scraper::HorseRaceResultScraperService.new(url: <データ取得先URL>).call
+  # HorseRaceモデルのスクレイピングを実施
+  # Usage: Scraper::HorseRaceScraperService.new(url: <データ取得先URL>).call
   # netkeiba の 競走馬データベースからデータを取得
   # （URL例）https://db.netkeiba.com/horse/2016104458/
-  class HorseRaceResultScraperService # rubocop:disable Metrics/ClassLength
+  class HorseRaceScraperService # rubocop:disable Metrics/ClassLength
     attr_reader :url
 
     def initialize(url:)
@@ -64,11 +64,11 @@ module Scraper
       reason_of_exclusion: lambda do |elements|
         case elements[:order_of_arrival].text
         when '中'
-          HorseRaceResult.reason_of_exclusions[:pull_up]
+          HorseRace.reason_of_exclusions[:pull_up]
         when '除'
-          HorseRaceResult.reason_of_exclusions[:scratch]
+          HorseRace.reason_of_exclusions[:scratch]
         when '取'
-          HorseRaceResult.reason_of_exclusions[:withdrawn]
+          HorseRace.reason_of_exclusions[:withdrawn]
         end
       end
     }.freeze
@@ -121,11 +121,10 @@ module Scraper
           Scraper::HorseScraperService.new(url: horse_url).call
         end
 
-        # HorseRaceResultのデータ保存
-        horse_race_result = HorseRaceResult
-                            .find_or_initialize_by(horse_id: attributes[:horse_id],
-                                                   race_id: attributes[:race_id])
-        horse_race_result.update_attributes!(attributes)
+        # HorseRaceのデータ保存
+        horse_race = HorseRace.find_or_initialize_by(horse_id: attributes[:horse_id],
+                                                     race_id: attributes[:race_id])
+        horse_race.update_attributes!(attributes)
       end
     end
 

--- a/app/services/scraper/race_abroad_scraper_service.rb
+++ b/app/services/scraper/race_abroad_scraper_service.rb
@@ -79,7 +79,7 @@ module Scraper
     # rubocop:enable Metrics/LineLength
 
     def create(attributes)
-      # HorseRaceResultのデータ保存
+      # HorseRaceのデータ保存
       race = Race.find_or_initialize_by(id: attributes[:id])
       race.update_attributes!(attributes)
     end

--- a/app/services/scraper/race_scraper_service.rb
+++ b/app/services/scraper/race_scraper_service.rb
@@ -14,7 +14,7 @@ module Scraper
 
     def call
       response = HTTParty.get(url)
-      create(parse(response))
+      parse_and_create(response)
     end
 
     private
@@ -59,18 +59,18 @@ module Scraper
       day_number: ->(elements) { elements[:day_number].text.gsub('日目', '') }
     }.freeze
 
-    def parse(response)
+    def parse_and_create(response)
       doc = Nokogiri::HTML(response)
       elements = elements(doc)
       attributes = {}
       OPERATOR.each_key do |column_name|
         attributes[column_name] = OPERATOR[column_name].call elements
       end
+      create(attributes)
       # RaceRegulationのデータ作成
       RaceRegulationScraperService.new(elements: elements).call
       # RacePrizeのデータ作成
       RacePrizeScraperService.new(elements: elements).call
-      attributes
     end
 
     # rubocop:disable Metrics/LineLength

--- a/app/views/horses/show.html.erb
+++ b/app/views/horses/show.html.erb
@@ -30,8 +30,8 @@
             </tr>
         </thead>
         <tbody>
-            <% @horse_race_results.each do |result| %>
-                <tr class="horse_race_result">
+            <% @horse_races.each do |result| %>
+                <tr class="horse_race">
                     <td><%= result.race.start.to_s :date %></td>
                     <td><%= result.race.name %></td>
                     <td><%= result.gate_number %></td>

--- a/app/views/races/show.html.erb
+++ b/app/views/races/show.html.erb
@@ -18,11 +18,11 @@
       </tr>
     </thead>
     <tbody>
-      <% @race_horses.each do |race_horse| %>
-        <tr class="race_horse">
-          <td><%= race_horse.gate_number %></td>
-          <td><%= race_horse.horse_number %></td>
-          <td><%= link_to race_horse.horse.name, race_horse.horse %></td>
+      <% @horse_races.each do |horse_race| %>
+        <tr class="horse_race">
+          <td><%= horse_race.gate_number %></td>
+          <td><%= horse_race.horse_number %></td>
+          <td><%= link_to horse_race.horse.name, horse_race.horse %></td>
         </tr>
       <% end %>
     </tbody>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -60,7 +60,7 @@ ja:
         good: 稍重
         yielding: 重
         soft: 不良
-    horse_race_result:
+    horse_race:
       reason_of_exclusion:
         pull_up: 競走中止
         scratch: 競走除外

--- a/db/migrate/20200917231806_change_race_hoses_to_race_horses.rb
+++ b/db/migrate/20200917231806_change_race_hoses_to_race_horses.rb
@@ -1,5 +1,0 @@
-class ChangeRaceHosesToRaceHorses < ActiveRecord::Migration[6.0]
-  def change
-    rename_table :race_hoses, :race_horses
-  end
-end

--- a/db/migrate/20200917234348_rename_hose_num_and_hose_num__column_to_race_horses.rb
+++ b/db/migrate/20200917234348_rename_hose_num_and_hose_num__column_to_race_horses.rb
@@ -1,5 +1,0 @@
-class RenameHoseNumAndHoseNumColumnToRaceHorses < ActiveRecord::Migration[6.0]
-  def change
-    rename_column :race_horses, :hose_num, :horse_number 
-  end
-end

--- a/db/migrate/20200924030442_add_id_to_race_horses.rb
+++ b/db/migrate/20200924030442_add_id_to_race_horses.rb
@@ -1,8 +1,0 @@
-#
-# add id column to race_horse table
-#
-class AddIdToRaceHorses < ActiveRecord::Migration[6.0]
-  def change
-    add_column :race_horses, :id, :primary_key, unsigned: true, first: true
-  end
-end

--- a/db/migrate/20200928000817_change_data_race_id_and_horse_id_to_race_horse.rb
+++ b/db/migrate/20200928000817_change_data_race_id_and_horse_id_to_race_horse.rb
@@ -1,6 +1,0 @@
-class ChangeDataRaceIdAndHorseIdToRaceHorse < ActiveRecord::Migration[6.0]
-  def change
-    change_column :race_horses, :race_id, :bigint
-    change_column :race_horses, :horse_id, :bigint
-  end
-end

--- a/db/migrate/20201005023350_remove_id_from_race_horses.rb
+++ b/db/migrate/20201005023350_remove_id_from_race_horses.rb
@@ -1,5 +1,0 @@
-class RemoveIdFromRaceHorses < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :race_horses, :id
-  end
-end

--- a/db/migrate/20201005023617_change_race_id_and_horse_id_results_to_race_horses.rb
+++ b/db/migrate/20201005023617_change_race_id_and_horse_id_results_to_race_horses.rb
@@ -1,5 +1,0 @@
-class ChangeRaceIdAndHorseIdResultsToRaceHorses < ActiveRecord::Migration[6.0]
-  def change
-    execute 'ALTER TABLE race_horses ADD PRIMARY KEY (race_id, horse_id);'
-  end
-end

--- a/db/migrate/20201105002706_change_datatype_to_race_horses.rb
+++ b/db/migrate/20201105002706_change_datatype_to_race_horses.rb
@@ -1,6 +1,0 @@
-class ChangeDatatypeToRaceHorses < ActiveRecord::Migration[6.0]
-  def change
-    change_column :race_horses, :gate_num, :integer
-    change_column :race_horses, :horse_number, :integer
-  end
-end

--- a/db/migrate/20201117033123_rename_gate_num_to_gate_number_to_race_horses.rb
+++ b/db/migrate/20201117033123_rename_gate_num_to_gate_number_to_race_horses.rb
@@ -1,5 +1,0 @@
-class RenameGateNumToGateNumberToRaceHorses < ActiveRecord::Migration[6.0]
-  def change
-    rename_column :race_horses, :gate_num, :gate_number
-  end
-end

--- a/db/migrate/20201125091358_change_datatype_race_id_and_horse_id_to_race_horses.rb
+++ b/db/migrate/20201125091358_change_datatype_race_id_and_horse_id_to_race_horses.rb
@@ -1,6 +1,0 @@
-class ChangeDatatypeRaceIdAndHorseIdToRaceHorses < ActiveRecord::Migration[6.0]
-  def change
-    change_column :race_horses, :race_id, :bigint
-    change_column :race_horses, :horse_id, :bigint
-  end
-end

--- a/db/migrate/20210125012554_horse_race_result_to_horse_race.rb
+++ b/db/migrate/20210125012554_horse_race_result_to_horse_race.rb
@@ -1,0 +1,5 @@
+class HorseRaceResultToHorseRace < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :horse_race_results, :horse_races
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_22_023739) do
+ActiveRecord::Schema.define(version: 2021_01_25_012554) do
 
-  create_table "horse_race_results", primary_key: ["horse_id", "race_id"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "horse_races", primary_key: ["horse_id", "race_id"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "horse_id", null: false
     t.string "race_id", null: false
     t.integer "gate_number"
@@ -32,8 +32,8 @@ ActiveRecord::Schema.define(version: 2021_01_22_023739) do
     t.integer "reason_of_exclusion"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["horse_id"], name: "index_horse_race_results_on_horse_id"
-    t.index ["race_id"], name: "index_horse_race_results_on_race_id"
+    t.index ["horse_id"], name: "index_horse_races_on_horse_id"
+    t.index ["race_id"], name: "index_horse_races_on_race_id"
   end
 
   create_table "horses", id: :bigint, default: nil, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -96,5 +96,5 @@ ActiveRecord::Schema.define(version: 2021_01_22_023739) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  add_foreign_key "horse_race_results", "horses"
+  add_foreign_key "horse_races", "horses"
 end

--- a/spec/factories/horse_races.rb
+++ b/spec/factories/horse_races.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :horse_race_result do
+  factory :horse_race do
     horse
     race
     sequence(:order_of_arrival)

--- a/spec/factories/horses.rb
+++ b/spec/factories/horses.rb
@@ -3,10 +3,10 @@ FactoryBot.define do
     sequence(:id)
     name { Faker::Name.name }
 
-    trait :with_horse_race_results do
+    trait :with_horse_races do
       6.times do
         after(:create) do |horse|
-          create(:horse_race_result, horse: horse)
+          create(:horse_race, horse: horse)
         end
       end
     end

--- a/spec/factories/race_horses.rb
+++ b/spec/factories/race_horses.rb
@@ -1,8 +1,0 @@
-FactoryBot.define do
-  factory :race_horse do
-    race
-    horse
-    sequence(:gate_number)
-    sequence(:horse_number)
-  end
-end

--- a/spec/factories/races.rb
+++ b/spec/factories/races.rb
@@ -11,11 +11,11 @@ FactoryBot.define do
     turn { Race.turns.values.sample }
     side { Race.sides.values .sample }
 
-    trait :with_race_horses do
+    trait :with_horse_races do
       6.times do
         after(:create) do |race|
           horse = create(:horse)
-          create(:race_horse, horse: horse, race: race)
+          create(:horse_race, horse: horse, race: race)
         end
       end
     end

--- a/spec/features/horses_spec.rb
+++ b/spec/features/horses_spec.rb
@@ -20,7 +20,7 @@ feature 'Horses' do
     before do
       races.each do |race|
         create(:race_result, race: race)
-        create(:horse_race_result, horse: horse, race: race)
+        create(:horse_race, horse: horse, race: race)
       end
     end
 
@@ -28,15 +28,15 @@ feature 'Horses' do
       visit horse_path(horse)
 
       # 全てのレース結果が画面に表示されていること
-      expect(page).to have_selector('tr.horse_race_result',
-                                    count: horse.horse_race_results.count)
+      expect(page).to have_selector('tr.horse_race',
+                                    count: horse.horse_races.count)
       # グラフエリア
       expect(page).to have_text(horse.name)
       # レース結果エリア
       expect(page.all('th').map(&:text))
         .to match(%w(日程 レース 枠番 馬番 オッズ 人気 順位 騎手 斤量 タイム 着差 通過順 後半3F 馬体重 増減 賞金))
-      result = HorseRaceResult.includes(:race).order('races.start DESC').first
-      expect(page.all('.horse_race_result')[0].all('td').map(&:text))
+      result = HorseRace.includes(:race).order('races.start DESC').first
+      expect(page.all('.horse_race')[0].all('td').map(&:text))
         .to match([
           result.race.start.to_s(:date),
           result.race.name,

--- a/spec/features/races_spec.rb
+++ b/spec/features/races_spec.rb
@@ -15,7 +15,7 @@ feature 'Races' do
   end
 
   feature 'show' do
-    let(:race) { create(:race, :with_race_horses) }
+    let(:race) { create(:race, :with_horse_races) }
     before do
       create_list(:race_prize, 5, race: race)
       create_list(:race_regulation, 5, race: race)
@@ -26,7 +26,7 @@ feature 'Races' do
 
       # レースに出走する競走馬が全て表示されていること
       expect(page)
-        .to have_selector('tr.race_horse', count: race.race_horses.count)
+        .to have_selector('tr.horse_race', count: race.horse_races.count)
 
       # 必要な項目が画面上に表示されていること
       race_schedule = [race.start.to_s(:date_hour_min),
@@ -45,8 +45,8 @@ feature 'Races' do
       expect(page).to have_text(race_schedule)
       expect(page).to have_text(race_condition)
       expect(page).to have_text(race_prizes)
-      expect(page).to have_text(race.race_horses.first.gate_number)
-      expect(page).to have_text(race.race_horses.first.horse_number)
+      expect(page).to have_text(race.horse_races.first.gate_number)
+      expect(page).to have_text(race.horse_races.first.horse_number)
       expect(page).to have_text(race.horses.first.name)
     end
   end

--- a/spec/helpers/races_helper_spec.rb
+++ b/spec/helpers/races_helper_spec.rb
@@ -7,11 +7,11 @@ describe RacesHelper do
       end
 
       it 'course_type, turn, side は表示されない' do
-        race_condition = [I18n.t("enums.race.course_type.#{race.course_type}"),
+        race_condition = [t("enums.race.course_type.#{race.course_type}"),
                           "#{race.distance}m",
-                          I18n.t("enums.race.turn.#{race.turn}")
+                          t("enums.race.turn.#{race.turn}")
                          ].concat(race.race_regulations.map do |regulation|
-                           I18n.t("enums.race_regulation.#{regulation.regulation}")
+                           t("enums.race_regulation.#{regulation.regulation}")
                          end).reject(&:blank?).join(' ')
         expect(helper.race_condition(race)).to eq(race_condition)
       end

--- a/spec/models/horse_race_spec.rb
+++ b/spec/models/horse_race_spec.rb
@@ -1,3 +1,3 @@
-describe HorseRaceResult do
+describe HorseRace do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/race_horse_spec.rb
+++ b/spec/models/race_horse_spec.rb
@@ -1,3 +1,0 @@
-describe RaceHorse do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/requests/races_spec.rb
+++ b/spec/requests/races_spec.rb
@@ -5,17 +5,17 @@ describe 'Races' do
     before do
       (1..18).to_a.shuffle.each do |n|
         horse = create(:horse)
-        create(:race_horse, horse: horse, race: race, horse_number: n)
+        create(:horse_race, horse: horse, race: race, horse_number: n)
       end
     end
 
     it 'レースに出走する競走馬が馬番の昇順でソートされていること' do
       get race_path(race)
       # インスタンス変数を取得する
-      race_horses = controller.instance_variable_get('@race_horses')
+      horse_races = controller.instance_variable_get('@horse_races')
 
       expect(response).to be_successful
-      expect(race_horses.pluck(:horse_number)).to eq((1..18).to_a)
+      expect(horse_races.pluck(:horse_number)).to eq((1..18).to_a)
     end
   end
 end

--- a/spec/services/generate_rpci_ave1f_scatter_plots_service_spec.rb
+++ b/spec/services/generate_rpci_ave1f_scatter_plots_service_spec.rb
@@ -10,7 +10,7 @@ describe GenerateRpciAve1fScatterPlotsService do
       before do
         races.each do |race|
           create(:race_result, race: race)
-          create(:horse_race_result, horse: horse, race: race)
+          create(:horse_race, horse: horse, race: race)
         end
       end
 
@@ -23,7 +23,7 @@ describe GenerateRpciAve1fScatterPlotsService do
       let(:race) { create(:race) }
       let!(:race_result) { create(:race_result, race: race) }
       before do
-        create(:horse_race_result, trait, horse: horse, race: race)
+        create(:horse_race, trait, horse: horse, race: race)
       end
 
       context '勝ったレースの場合' do


### PR DESCRIPTION
  - エラーメッセージを日本語翻訳できるようにした
    - rails-i18nのgemをインストール
    - I18n.t は省略可能になったので t. に変更(spec/配下以外)
  - horse_race_result を horse_race に名称変更
    - ソース中のhorse_race_resultsをhorse_racesにrename
    - rails db:migrate を用いてテーブル名を rename
  - race_horse を削除
    - ソース中のrace_resultsを削除。代わりにhorse_racesを呼び出す形に修正
    - race_horse モデルの削除
    - race_horse に関する migration ファイルを削除
  - race_scraper_serviceのバグ修正